### PR TITLE
Remove hardhat-change-network plugin

### DIFF
--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -280,13 +280,6 @@ const communityPlugins: IPlugin[] = [
     tags: ["solidity", "storage"],
   },
   {
-    name: "hardhat-change-network",
-    author: "David Mihal",
-    authorUrl: "https://github.com/dmihal",
-    description: "Allows changing the current network in Hardhat.",
-    tags: ["Testing"],
-  },
-  {
     name: "hardhat-packager",
     author: "Paul Razvan Berg",
     authorUrl: "https://github.com/paulrberg",


### PR DESCRIPTION
The plugin is unmaintained, [asked if it should be removed](https://github.com/NomicFoundation/hardhat/pull/5703#issuecomment-2325571462) and got an [affirmative response](https://github.com/NomicFoundation/hardhat/pull/5703#issuecomment-2327205196).